### PR TITLE
Add `issue_number` input to configure target to post comments to

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Defaults to `latest`.
   - If set to `true`, will post comment every time.
   - If set to `nonzero`, will post comment only if any checks failed or there's changes to the Terraform plan ([returncode](#outputs) other than 0).
 - `github_token`: (optional) Github access token, required to post PR comments.
+- `issue_number`: (optional) If set, post comment to a specific issue or PR instead of the current one.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     description: "Hide state refresh output from report"
   github_token:
     description: "Github token to post PR comment"
+  issue_number:
+    description: "Post comment to a specific issue or PR instead of the current one"
 outputs:
   returncode:
     description: "Terraform check return code"
@@ -118,8 +120,10 @@ runs:
           const fs = require('fs')
           const body = fs.readFileSync("report.md", "utf8")
 
+          const issue_number = Number('${{ inputs.issue_number }}') || context.issue.number
+
           github.rest.issues.createComment({
-            issue_number: context.issue.number,
+            issue_number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: body


### PR DESCRIPTION
This input option allows the user to configure the target issue/PR number to post the `terraform-check` comments to.

If not specified, the default value is to post to the issue/PR in current context.