### PR TITLE
Allow using an already installed terraform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ steps:
 - `directory`: (required) One or more directories separated by space, containing the Terraform configuration.
 - `terraform_version`: (optional) Terraform version to use. 
 You can set version for each directory if checking on multiple directories. 
+If set to `system`, the action will use the terraform version already installed.
 Defaults to `latest`.
 - `hide_refresh`: (optional) Hide state refresh output from report
 - `post_comment`: (optional) Whether to post [detailed report](#detailed-report) as pull request comment. 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ steps:
     terraform_version: 1.1.7
 ```
 
+If terraform is already installed, it can be used:
+```yaml
+steps:
+- uses: HENNGE/terraform-check@v1
+  with:
+    directory: infra/tf
+    terraform_version: system
+```
+
 Multiple directories can be set as input, separated by space:
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "One or more directories separated by space in which to run the checks"
     required: true
   terraform_version:
-    description: "Terraform version to run the check against"
+    description: "Terraform version to run the check against. Set to 'system' to use the system terraform."
     default: "latest"
   post_comment:
     description: "Post check result to PR comment if set as true"
@@ -37,6 +37,7 @@ runs:
         python-version: '3.9'
 
     - name: Setup tfenv
+      if: "${{ inputs.terraform_version != 'system' }}"
       run: |
         if [[ ! -d ~/.tfenv ]]; then
           git clone -b v3.0.0 https://github.com/tfutils/tfenv.git ~/.tfenv
@@ -68,11 +69,18 @@ runs:
             printf "\n\n---\n\n" >> report.md
           fi
 
-          # Change Terraform version
-          tfenv install "${versions[$i]}"
-          tfenv use "${versions[$i]}"
+          if [ "${versions[$i]}" = "system" ] ; then
+            echo "Using system provided terraform"
+            terraform --version
+          elif [ -z "${versions[$i]}" ] ; then
+            : # using whatever we setup previously
+          else
+            # Change Terraform version
+            tfenv install "${versions[$i]}"
+            tfenv use "${versions[$i]}"
+          fi
 
-          venv/bin/python ${{ github.action_path }}/tfcheck.py "${directories[$i]}" -report report.md $hide | tee >(tail -1 >> result.txt)
+          venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md $hide | tee >(tail -1 >> result.txt)
           ret=${PIPESTATUS[0]}
 
           if [ "$ret" -eq 1 ]; then

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         python-version: '3.9'
 
     - name: Setup tfenv
-      if: "${{ inputs.terraform_version != 'system' }}"
+      if: ${{ inputs.terraform_version != 'system' }}
       run: |
         if [[ ! -d ~/.tfenv ]]; then
           git clone -b v3.0.0 https://github.com/tfutils/tfenv.git ~/.tfenv


### PR DESCRIPTION
If a workflow has already installed terraform we can reuse it (and it
might also be using the tool cache for it as well).