### PR TITLE
Support updating an existing comment with check results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ steps:
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+If `post_comment` is set to `update`, the previous comment will be updated if the action runs again.
+```yaml
+steps:
+- uses: HENNGE/terraform-check@v1
+  with:
+    directory: infra/tf
+    post_comment: update
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 If `post_comment` is set to `nonzero`, comments will only be posted if return code is not zero (checks failed or there are changes).
 ```yaml
 steps:
@@ -90,8 +100,9 @@ You can set version for each directory if checking on multiple directories.
 Defaults to `latest`.
 - `hide_refresh`: (optional) Hide state refresh output from report
 - `post_comment`: (optional) Whether to post [detailed report](#detailed-report) as pull request comment. 
-  - If set to `true`, will post comment every time.
-  - If set to `nonzero`, will post comment only if any checks failed or there's changes to the Terraform plan ([returncode](#outputs) other than 0).
+  - If set to `true`, will post a comment every time.
+  - If set to `update`, will post a comment and then update the existing comment on any subsequent runs.
+  - If set to `nonzero`, will post a comment only if any checks failed or there's changes to the Terraform plan ([returncode](#outputs) other than 0).
 - `github_token`: (optional) Github access token, required to post PR comments.
 - `issue_number`: (optional) If set, post comment to a specific issue or PR instead of the current one.
 

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,7 @@ inputs:
     description: "Terraform version to run the check against"
     default: "latest"
   post_comment:
-    description: "Post check result to PR comment if set as true"
-  update_comment:
-    description: "Post check result to PR comment if set as true, reusing a previous comment if possible."
+    description: "Post check result to PR comment if set as true. Set to 'update' to update the existing comment on subsequent runs, after posting the initial comment."
   hide_refresh:
     description: "Hide state refresh output from report"
   github_token:
@@ -115,7 +113,7 @@ runs:
       shell: bash
 
     - uses: actions/github-script@v6
-      if: ${{ inputs.post_comment == 'true' || inputs.update_comment == 'true' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
+      if: ${{ inputs.post_comment == 'true' || inputs.post_comment == 'update' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -125,7 +123,7 @@ runs:
           const issue_number = Number('${{ inputs.issue_number }}') || context.issue.number
 
           let botComment = null;
-          if ('${{ inputs.update_comment }}' == 'true') {
+          if ('${{ inputs.post_comment }}' == 'update') {
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
     default: "latest"
   post_comment:
     description: "Post check result to PR comment if set as true"
+  update_comment:
+    description: "Post check result to PR comment if set as true, reusing a previous comment if possible."
   hide_refresh:
     description: "Hide state refresh output from report"
   github_token:
@@ -113,7 +115,7 @@ runs:
       shell: bash
 
     - uses: actions/github-script@v6
-      if: ${{ inputs.post_comment == 'true' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
+      if: ${{ inputs.post_comment == 'true' || inputs.update_comment == 'true' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -122,12 +124,34 @@ runs:
 
           const issue_number = Number('${{ inputs.issue_number }}') || context.issue.number
 
-          github.rest.issues.createComment({
-            issue_number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: body
-          })
+          let botComment = null;
+          if ('${{ inputs.update_comment }}' == 'true') {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform check on')
+            });
+          }
+
+          if (botComment) {
+            github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: body
+            });
+          } else {
+            github.rest.issues.createComment({
+              issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+          }
 
     - run: |
         if [[ ${{ steps.check.outputs.returncode }} -eq 1 ]]; then


### PR DESCRIPTION
Open to suggestions how to parameterise this best.

Should it be required to configure `post_comment: true` and then
also some `update_comment: true` or should they be to separate configs.