### PR TITLE
Pass correct issue number to listComments when updating comments.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,9 +133,9 @@ runs:
           let botComment = null;
           if ('${{ inputs.post_comment }}' == 'update') {
             const { data: comments } = await github.rest.issues.listComments({
+              issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
             });
 
             botComment = comments.find(comment => {


### PR DESCRIPTION
If the action is configured with an explicit issue number, it must
also be passed into the `listComments` search.

I did not test for this case when I initially added this and was passing
in the one from the context, not the explicit one.