### PR TITLE
feat: initial support for passing args to `terraform plan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ steps:
     terraform_version: 1.1.7
 ```
 
+If checking directories, you can pass different plan arguments for each:
+```yaml
+steps:
+- uses: HENNGE/terraform-check@v1
+  with:
+    directory: infra/tf infra/tf2
+    plan_args: '["-var foo_version=${{ env.FOO_VERSION }}", ""]'
+```
+
 [Detailed report](#detailed-report) can be automatically posted as a pull request comment.
 Make sure that Github token has permission to write into pull requests.
 ```yaml
@@ -115,6 +124,12 @@ Defaults to `latest`.
   - If set to `nonzero`, will post a comment only if any checks failed or there's changes to the Terraform plan ([returncode](#outputs) other than 0).
 - `github_token`: (optional) Github access token, required to post PR comments.
 - `issue_number`: (optional) If set, post comment to a specific issue or PR instead of the current one.
+- `plan_args`: (optional) If set, additional arguments to pass to `terraform plan`.
+Note that this is passed through as serialised json array, corresponding to the
+array of directories passed. (This is so you can have different args per
+terraform plan invocation). The strings will be passed directory into the shell,
+so if you have spaces in variables you will need to quote them, but escape the
+quotes (and then escape in json).
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
   terraform_version:
     description: "Terraform version to run the check against. Set to 'system' to use the system terraform."
     default: "latest"
+  plan_args:
+    description: "Optional: Additional arguments to pass to terraform plan. This should be passed as json array."
   post_comment:
     description: "Post check result to PR comment if set as true. Set to 'update' to update the existing comment on subsequent runs, after posting the initial comment."
   hide_refresh:
@@ -51,10 +53,13 @@ runs:
       shell: bash
 
     - id: check
+      env:
+        PLAN_ARGS: ${{ inputs.plan_args }}
       run: |
         set +e
         read -r -a directories <<< "${{ inputs.directory }}"
         read -r -a versions <<< "${{ inputs.terraform_version }}"
+        readarray -t plan_args < <(printf '%s\n' "$PLAN_ARGS" | jq -r '.[] | if . == null then "" else . end')
 
         if [ "${{ inputs.hide_refresh }}" = "true" ]; then
           hide=-hide-refresh
@@ -80,7 +85,12 @@ runs:
             tfenv use "${versions[$i]}"
           fi
 
-          venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md $hide | tee >(tail -1 >> result.txt)
+          if [ -z "${plan_args[$i]}" ] ; then
+            venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md $hide | tee >(tail -1 >> result.txt)
+          else
+            printf "Passing these args to plan: %s\n" "${plan_args[$i]}"
+            venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md -plan-args "${plan_args[$i]}" $hide | tee >(tail -1 >> result.txt)
+          fi
           ret=${PIPESTATUS[0]}
 
           if [ "$ret" -eq 1 ]; then


### PR DESCRIPTION
No special handling of shell arguments is made here. The action
configuration needs to account for shell escaping for now.

This is not really ideal, but given how multiple directories were added in
f39c110 (with list of directories separated by spaces) and a matching array
with the tf versions, I'm not really sure of a better way.

Perhaps eventually a new major release where we change how all the parameters
are passed could sort it out so that instead we are explicit about the tuples
of directory+tfversion+args instead of trying to match them across three
arrays.

Anyway, for our use case, this change allows us to reduce a few hundred lines
of terraform plan output into an empty one since we can pass in a version
number instead of defaulting to `latest` during pull request pr checks.