### PR TITLE
fix: check for directory before updating bot comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,8 +138,9 @@ runs:
               repo: context.repo.repo,
             });
 
+            directory = '${{ inputs.directory }}'.split(' ')[0]
             botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform check on')
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform check on `${directory}`)
             });
           }
 

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
 
             directory = '${{ inputs.directory }}'.split(' ')[0]
             botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform check on `${directory}`)
+              return comment.user.type === 'Bot' && comment.body.includes(`Terraform check on ${directory}`)
             });
           }
 

--- a/action.yml
+++ b/action.yml
@@ -138,9 +138,9 @@ runs:
               repo: context.repo.repo,
             });
 
-            directory = '${{ inputs.directory }}'.split(' ')[0]
+            directories = '${{ inputs.directory }}'.split(' ')
             botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(`Terraform check on ${directory}`)
+              return comment.user.type === 'Bot' && directories.every(dir => comment.body.includes(`Terraform check on ${dir}`)) 
             });
           }
 


### PR DESCRIPTION
## Overview

When working with multiple accounts, we usually run this action on different directories under separate jobs and the current behavior will overwrite the first comments with the last to finish.

This PR adds a check for the directory to avoid overwriting comments written by other jobs.

Let me know if you can think of a better way to avoid this issue.