### PR TITLE
feat: add support for planning with opentofu

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   terraform_version:
     description: "Terraform version to run the check against. Set to 'system' to use the system terraform."
     default: "latest"
+  terraform_binary:
+    description: "Terraform binary to use. Defaults to 'terraform'. Can be set to 'tofu' to use opentofu."
+    default: "terraform"
   plan_args:
     description: "Optional: Additional arguments to pass to terraform plan. This should be passed as json array."
   post_comment:
@@ -37,6 +40,22 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+
+    - id: set-binary
+      env:
+        TERRAFORM_BINARY: ${{ inputs.terraform_binary }}
+      run: |
+        # sanitise input
+        if [[ "$TERRAFORM_BINARY" == "tofu" ]] ; then
+          printf 'TF=%s\n' "tofu" >> "$GITHUB_ENV"
+        elif [[ "$TERRAFORM_BINARY" == "terraform" ]] ; then
+          printf 'TF=%s\n' "terraform" >> "$GITHUB_ENV"
+        else
+          1>&2 printf 'Unsupported terraform binary %s\n' "$TERRAFORM_BINARY"
+          exit 1
+        fi
+      shell: bash
+
 
     - name: Setup tenv
       if: ${{ inputs.terraform_version != 'system' }}
@@ -101,14 +120,14 @@ runs:
           fi
 
           if [ "${versions[$i]}" = "system" ] ; then
-            echo "Using system provided terraform"
-            terraform --version
+            echo "Using system provided $TF"
+            "$TF" --version
           elif [ -z "${versions[$i]}" ] ; then
             : # using whatever we setup previously
           else
-            # Change Terraform version
-            tenv tf install "${versions[$i]}"
-            tenv tf use "${versions[$i]}"
+            # Change version
+            tenv "$TF" install "${versions[$i]}"
+            tenv "$TF" use "${versions[$i]}"
           fi
 
           if [ -z "${plan_args[$i]}" ] ; then

--- a/tfcheck.py
+++ b/tfcheck.py
@@ -7,10 +7,11 @@ from typing import Optional
 
 from jinja2 import Environment, FileSystemLoader
 
-FMT_CMD = "terraform fmt -check=true -write=false -recursive -diff"
-INIT_CMD = "terraform init -no-color"
-VALIDATE_CMD = "terraform validate -no-color"
-PLAN_CMD = "terraform plan -detailed-exitcode -no-color"
+TF_CMD = os.environ.get("TF", "terraform")
+FMT_CMD = f"{TF_CMD} fmt -check=true -write=false -recursive -diff"
+INIT_CMD = f"{TF_CMD} init -no-color"
+VALIDATE_CMD = f"{TF_CMD} validate -no-color"
+PLAN_CMD = f"{TF_CMD} plan -detailed-exitcode -no-color"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("path", help="path to run terraform checks", type=str)


### PR DESCRIPTION
I was looking for the simplest way to add these without any breaking
change for existing users. I think maybe this is pragmatic enough.

For now, the commands are all drop in - just replace the binary, so the
action just needs a way for that to be passed in.