### PR TITLE
fix: set auto-install env to true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,6 @@ runs:
         fi
       shell: bash
 
-
     - name: Setup tenv
       if: ${{ inputs.terraform_version != 'system' }}
       run: |
@@ -100,6 +99,7 @@ runs:
     - id: check
       env:
         PLAN_ARGS: ${{ inputs.plan_args }}
+        TENV_AUTO_INSTALL: true
       run: |
         set +e
         read -r -a directories <<< "${{ inputs.directory }}"


### PR DESCRIPTION
## Overview

After upgrading to the latest version with the recent tenv migration we started to see our jobs failing with the following message

> Auto-install is disabled. To install Terraform version 1.10.5, you can set environment variable TENV_AUTO_INSTALL=true, or install it via any of the following command: 'tenv terraform install', 'tenv terraform install 1.10.5'
Failed to detect a version allowing to call terraform : no compatible version found locally

Not sure if this is the best place to have this but I believe auto-installing the detected version of 
Terraform or Tofu by default makes sense

ref: https://github.com/tofuutils/tenv?tab=readme-ov-file#environment-variables