### PR TITLE
chore: bump actions/setup-python to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 


### PR DESCRIPTION
This is causing a deprecation warning now:

```
Node.js 20 actions are deprecated.
```