### PR TITLE
chore: bump github-script to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
         echo "$delimiter" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v8
       if: ${{ inputs.post_comment == 'true' || inputs.post_comment == 'update' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
       with:
         github-token: ${{ inputs.github_token }}


### PR DESCRIPTION
This is causing a deprecation warning now:

```
Node.js 20 actions are deprecated.
```