### PR TITLE
chore: bump tenv version to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       env:
         # renovate: datasource=github-releases depName=tofuutils/tenv
-        TENV_VERSION: 'v4.7.21'
+        TENV_VERSION: 'v4.10.1'
 
     - run: |
         python -m venv venv


### PR DESCRIPTION
To allow support for passing `TENV_VALIDATION` to allow the temporary fix for - https://github.com/tofuutils/tenv/issues/575