### PR TITLE
fix: add tenv-validation workaround

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,8 @@ runs:
       env:
         PLAN_ARGS: ${{ inputs.plan_args }}
         TENV_AUTO_INSTALL: true
+        # Workaround for tofuutils/tenv#575
+        TENV_VALIDATION: sha
       run: |
         set +e
         read -r -a directories <<< "${{ inputs.directory }}"


### PR DESCRIPTION
Add it to the action as well so we don't have to add it in the caller side.