### PR TITLE
fix: pin transitive github actions to SHA instead of floating tags

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -13,9 +13,9 @@ jobs:
   pr_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: HENNGE/conventional-pull-request-action@v0.2.1
+      - uses: HENNGE/conventional-pull-request-action@b92ba151c37ddfcf8abe522ae04be1ae0f7eaa80 # v0.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -9,12 +9,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           release-type: simple
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Update major version tag
         if: ${{ steps.release.outputs.release_created }}

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.12"
 
@@ -177,7 +177,7 @@ runs:
         echo "$delimiter" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       if: ${{ inputs.post_comment == 'true' || inputs.post_comment == 'update' || ( inputs.post_comment == 'nonzero' && steps.check.outputs.returncode != 0 ) }}
       with:
         github-token: ${{ inputs.github_token }}


### PR DESCRIPTION
Hello there,

Transitive actions in this github action are not pinned to SHA, which makes the users with the following settings turned on sad :(

<img width="435" height="43" alt="image" src="https://github.com/user-attachments/assets/ecdd88ab-edb8-4142-ad3b-e5fac1ed55ff" />

```
Error: The actions actions/setup-python@v6 and actions/github-script@v8 are not allowed in fluxth/sadness because all actions must be pinned to a full-length commit SHA.
```

This PR pins them to current version, Renovate can be used to update these action while they're pinned.