### PR TITLE
feat: add parallel input to check all directories concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ steps:
     terraform_version: 1.1.7
 ```
 
+Multiple directories are checked one after another by default. Set `parallel` to check them all at once:
+```yaml
+steps:
+- uses: HENNGE/terraform-check@v1
+  with:
+    directory: infra/tf infra/tf2 infra/tf3
+    parallel: true
+```
+
 If checking directories, you can pass different plan arguments for each:
 ```yaml
 steps:
@@ -125,8 +134,12 @@ steps:
 - `terraform_version`: (optional) Terraform version to use. 
 You can set version for each directory if checking on multiple directories. 
 If set to `system`, the action will use the terraform version already installed.
-Defaults to `latest`.
+It takes precedence over version files in a directory, such as `.terraform-version`.
+Defaults to the version resolved from those files, or to `latest` when a directory has none.
 - `terraform_binary`: (optional) Terraform binary to use. Defaults to `terraform`. Set to `tofu` to use opentofu.
+- `parallel`: (optional) If set to `true`, check all directories concurrently instead of one after another.
+Output is always reported in the order the directories were given, whatever this is set to.
+Do not enable it together with a shared `plugin_cache_dir`, which Terraform does not support concurrent use of.
 - `hide_refresh`: (optional) Hide state refresh output from report
 - `post_comment`: (optional) Whether to post [detailed report](#detailed-report) as pull request comment. 
   - If set to `true`, will post a comment every time.

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,12 @@ inputs:
     description: "One or more directories separated by space in which to run the checks"
     required: true
   terraform_version:
-    description: "Terraform version to run the check against. Set to 'system' to use the system terraform."
-    default: "latest"
+    description: "Terraform version to run the check against. Defaults to the version files of the directory, or the latest version when it has none. Set to 'system' to use the system terraform."
   terraform_binary:
     description: "Terraform binary to use. Defaults to 'terraform'. Can be set to 'tofu' to use opentofu."
     default: "terraform"
+  parallel:
+    description: "Check all directories concurrently if set as true. Defaults to checking them one after another."
   plan_args:
     description: "Optional: Additional arguments to pass to terraform plan. This should be passed as json array."
   post_comment:
@@ -48,8 +49,10 @@ runs:
         # sanitise input
         if [[ "$TERRAFORM_BINARY" == "tofu" ]] ; then
           printf 'TF=%s\n' "tofu" >> "$GITHUB_ENV"
+          printf 'TF_VERSION_ENV=%s\n' "TOFUENV_TOFU_VERSION" >> "$GITHUB_ENV"
         elif [[ "$TERRAFORM_BINARY" == "terraform" ]] ; then
           printf 'TF=%s\n' "terraform" >> "$GITHUB_ENV"
+          printf 'TF_VERSION_ENV=%s\n' "TFENV_TERRAFORM_VERSION" >> "$GITHUB_ENV"
         else
           1>&2 printf 'Unsupported terraform binary %s\n' "$TERRAFORM_BINARY"
           exit 1
@@ -98,10 +101,13 @@ runs:
 
     - id: check
       env:
+        PARALLEL: ${{ inputs.parallel }}
         PLAN_ARGS: ${{ inputs.plan_args }}
         TENV_AUTO_INSTALL: true
       run: |
         set +e
+        rm -f report.md result.txt
+        tmp=$(mktemp -d)
         read -r -a directories <<< "${{ inputs.directory }}"
         read -r -a versions <<< "${{ inputs.terraform_version }}"
         readarray -t plan_args < <(printf '%s\n' "$PLAN_ARGS" | jq -r '.[] | if . == null then "" else . end')
@@ -112,49 +118,69 @@ runs:
 
         len=${#directories[@]}
 
+        # An empty version keeps the previous directory's one, and is left to tenv to resolve
+        # from the version files of the directory itself.
+        for (( i=0; i<len; i++)); do
+          if [ -n "${versions[$i]}" ] ; then
+            version="${versions[$i]}"
+            if [ "$version" = "system" ] ; then
+              echo "Using system provided $TF"
+              "$TF" --version
+            fi
+          fi
+          versions[$i]="$version"
+        done
+
+        # tenv cannot run concurrently, so install what every directory resolves to up front.
+        for (( i=0; i<len; i++)); do
+          case "${versions[$i]}" in
+            system) ;;
+                "") ( cd "${directories[$i]}" && tenv "$TF" install ) ;;
+                 *) tenv "$TF" install "${versions[$i]}" ;;
+          esac
+        done
+
+        for (( i=0; i<len; i++)); do
+          printf 'Starting check on %s\n' "${directories[$i]}"
+
+          (
+            [ "${versions[$i]}" = "system" ] || export "$TF_VERSION_ENV=${versions[$i]}"
+            venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report "$tmp/$i.md" -plan-args "${plan_args[$i]}" $hide
+            echo $? > "$tmp/$i.ret"
+          ) > "$tmp/$i.log" 2>&1 &
+
+          [ "$PARALLEL" = "true" ] || wait
+        done
+        wait
+
+        # Replay in input order, so the result does not depend on which check finished first
         returncode=0
         for (( i=0; i<len; i++)); do
+          echo "::group::Terraform check on ${directories[$i]}"
+          cat "$tmp/$i.log"
+          echo "::endgroup::"
+
           # Append three dashes between reports
           if [ "$i" -gt 0 ]; then
             printf "\n\n---\n\n" >> report.md
           fi
+          cat "$tmp/$i.md" >> report.md
 
-          if [ "${versions[$i]}" = "system" ] ; then
-            echo "Using system provided $TF"
-            "$TF" --version
-          elif [ -z "${versions[$i]}" ] ; then
-            : # using whatever we setup previously
-          else
-            # Change version
-            tenv "$TF" install "${versions[$i]}"
-            tenv "$TF" use "${versions[$i]}"
-          fi
-
-          if [ -z "${plan_args[$i]}" ] ; then
-            venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md $hide | tee >(tail -1 >> result.txt)
-          else
-            printf "Passing these args to plan: %s\n" "${plan_args[$i]}"
-            venv/bin/python "${{ github.action_path }}/tfcheck.py" "${directories[$i]}" -report report.md -plan-args "${plan_args[$i]}" $hide | tee >(tail -1 >> result.txt)
-          fi
-          ret=${PIPESTATUS[0]}
+          result=$(tail -1 "$tmp/$i.log")
+          echo "$result" >> result.txt
+          ret=$(cat "$tmp/$i.ret" 2>/dev/null || echo 1)
 
           if [ "$ret" -eq 1 ]; then
-            echo "::error ::$(tail -1 result.txt)"
+            echo "::error ::$result"
           elif [ "$ret" -eq 2 ]; then
-            echo "::warning ::$(tail -1 result.txt)"
+            echo "::warning ::$result"
           fi
 
-          # Set exitcode to 1 if any check failed
-          # Set exitcode to 2 if any check contains plan change
-          if [ "$returncode" -eq 0 ]; then
-            returncode=$ret
-          elif [ "$returncode" -eq 2 ]; then
-            if [ "$ret" -eq 1 ]; then
-              returncode=1
-            else
-              returncode=2
-            fi
-          fi
+          # A failed check (1) takes precedence over plan changes (2)
+          case "$ret" in
+            1) returncode=1 ;;
+            2) [ "$returncode" -eq 0 ] && returncode=2 ;;
+          esac
         done
 
         echo "returncode=$returncode" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Overviews

I found that the Terraform check jobs end up taking a significant amount of time if we are checking a number of directories sequentially. 
Even though a matrix can be used to run the individual checks on different runners, having a `parallel` option that runs the refresh and plan steps concurrently and consolidates the output in one comment per environment is nice to have..

Also updates the logs to group the output per directory in one place.